### PR TITLE
PHP 8 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     }
   },
   "require": {
-    "graham-campbell/github": "^9.2",
+    "graham-campbell/github": "^10.3",
     "php-http/guzzle7-adapter": "^1.0",
     "ramsey/uuid": "^4.0",
     "statamic/cms": "^3.0"


### PR DESCRIPTION
The plugin isn't working with PHP 8, because of `graham-campbell/github`, so i changed this package to the latest version.

```
composer require ohseesoftware/oh-see-gists
Using version ^3.1 for ohseesoftware/oh-see-gists
./composer.json has been updated
Running composer update ohseesoftware/oh-see-gists
> Statamic\Console\Composer\Scripts::preUpdateCmd
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - graham-campbell/github[v9.2.0, ..., 9.8.x-dev] require php ^7.2.5 -> your php version (8.0.7) does not satisfy that requirement.
    - ohseesoftware/oh-see-gists v3.1.0 requires graham-campbell/github ^9.2 -> satisfiable by graham-campbell/github[v9.2.0, ..., 9.8.x-dev].
    - Root composer.json requires ohseesoftware/oh-see-gists ^3.1 -> satisfiable by ohseesoftware/oh-see-gists[v3.1.0].
```
